### PR TITLE
DBAAS-151: Percent encoding username and password for special chars

### DIFF
--- a/pkg/binding/convert/converter_test.go
+++ b/pkg/binding/convert/converter_test.go
@@ -99,7 +99,7 @@ func TestMongoDBConverter_Convert(t *testing.T) {
 					Provider:    "atlas",
 					Properties: map[string]string{
 						"host":     "cluster0.ubajs.mongodb.net",
-						"username": "a-db-user",
+						"username": "#a-db-user:",
 						"password": "p#a:s[s123/w[ord@",
 						"srv":      "true",
 						"options":  "some-db-options",
@@ -107,7 +107,7 @@ func TestMongoDBConverter_Convert(t *testing.T) {
 					},
 				},
 			},
-			want: "mongodb+srv://a-db-user:p%23a%3As%5Bs123%2Fw%5Bord%40@cluster0.ubajs.mongodb.net/remote-db?some-db-options",
+			want: "mongodb+srv://%23a-db-user%3A:p%23a%3As%5Bs123%2Fw%5Bord%40@cluster0.ubajs.mongodb.net/remote-db?some-db-options",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/binding/convert/converter_test.go
+++ b/pkg/binding/convert/converter_test.go
@@ -90,6 +90,25 @@ func TestMongoDBConverter_Convert(t *testing.T) {
 			},
 			want: "mongodb+srv://a-db-user:password@example.com:10011",
 		},
+		{
+			name: "Correct connection string returned - password contains special characters",
+			args: args{
+				binding: fileconfig.ServiceBinding{
+					Name:        "local",
+					BindingType: "mongodb",
+					Provider:    "atlas",
+					Properties: map[string]string{
+						"host":     "cluster0.ubajs.mongodb.net",
+						"username": "a-db-user",
+						"password": "p#a:s[s123/w[ord@",
+						"srv":      "true",
+						"options":  "some-db-options",
+						"database": "remote-db",
+					},
+				},
+			},
+			want: "mongodb+srv://a-db-user:p%23a%3As%5Bs123%2Fw%5Bord%40@cluster0.ubajs.mongodb.net/remote-db?some-db-options",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Both username and password are percent encoded if any special char is found in them - based on https://docs.mongodb.com/manual/reference/connection-string/. Also updated the test for this scenario.